### PR TITLE
Fix manifest icon paths

### DIFF
--- a/resources/manifest.json
+++ b/resources/manifest.json
@@ -12,49 +12,49 @@
   "categories": ["games", "utilities"],
   "icons": [
     {
-      "src": "resources/icons/icon-72x72.png",
+      "src": "icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "resources/icons/icon-96x96.png",
+      "src": "icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "resources/icons/icon-128x128.png",
+      "src": "icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "resources/icons/icon-144x144.png",
+      "src": "icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "resources/icons/icon-152x152.png",
+      "src": "icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "resources/icons/icon-192x192.png",
+      "src": "icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "resources/icons/icon-384x384.png",
+      "src": "icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "resources/icons/icon-512x512.png",
+      "src": "icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable any"
@@ -68,7 +68,7 @@
       "url": "/tacops/?map=standoff",
       "icons": [
         {
-          "src": "resources/icons/icon-96x96.png",
+          "src": "icons/icon-96x96.png",
           "sizes": "96x96"
         }
       ]
@@ -80,7 +80,7 @@
       "url": "/tacops/?map=firing_range",
       "icons": [
         {
-          "src": "resources/icons/icon-96x96.png",
+          "src": "icons/icon-96x96.png",
           "sizes": "96x96"
         }
       ]


### PR DESCRIPTION
## Summary
- correct manifest icon paths so they resolve correctly on GitHub Pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688843189a088333958b54a2da8b677c