### PR TITLE
Ensure dark background and remove custom map overflow

### DIFF
--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -1,4 +1,6 @@
-  <style>
+    html {
+      background-color: #111;
+    }
     body {
       margin: 0;
       padding: 0;
@@ -24,6 +26,7 @@
       transition: transform 0.3s ease;
       transform: translateX(0);
       overflow-y: auto !important;
+      overflow-x: hidden;
       max-height: 100vh !important;
     }
 
@@ -35,7 +38,7 @@
     }
 
     .map-selector {
-      width: 220px;
+      width: 100%;
       background: #181c24;
       border-radius: 12px;
       box-shadow: 0 4px 16px rgba(0,0,0,0.18);
@@ -59,7 +62,7 @@
       text-align: left;
     }
 
-    .map-selector select {
+.map-selector select {
       width: 100%;
       font-size: 1.1rem;
       padding: 0.6rem 0.5rem;
@@ -76,6 +79,7 @@
       box-sizing: border-box;
       margin-bottom: 0;
       margin-top: 0;
+      overflow: hidden;
     }
 
     .map-selector select:focus {
@@ -102,6 +106,7 @@
       font-size: 1rem;
       transition: background 0.2s;
       cursor: pointer;
+      box-sizing: border-box;
     }
 
     .whiteboard-controls button:hover {
@@ -146,7 +151,8 @@
 
     .map-container {
       position: relative;
-      width: fit-content;
+      width: 100%;
+      max-width: 100%;
       height: auto;
       margin: 0 auto;
       max-height: 100vw;
@@ -155,7 +161,7 @@
 
     .map-container img {
       display: block;
-      max-width: 100%;
+      width: 100%;
       height: auto;
     }
 
@@ -165,6 +171,8 @@
       left: 0;
       cursor: crosshair;
       border: 2px solid #00ff00;
+      max-width: 100%;
+      height: auto;
       /* width: auto !important; */
       /* height: auto !important; */
     }
@@ -261,6 +269,7 @@
       border: 1px solid #444;
       border-radius: 8px;
       font-size: 1rem;
+      box-sizing: border-box;
     }
 
     .board-select {
@@ -272,6 +281,7 @@
       border: 1px solid #444;
       border-radius: 8px;
       font-size: 1rem;
+      box-sizing: border-box;
     }
 
     .board-input:focus,
@@ -510,7 +520,7 @@
     }
 
     .upload-section {
-      width: 220px;
+      width: 100%;
       background: #181c24;
       border-radius: 12px;
       box-shadow: 0 4px 16px rgba(0,0,0,0.18);
@@ -542,6 +552,7 @@
       cursor: pointer;
       transition: background 0.2s, color 0.2s;
       outline: none;
+      box-sizing: border-box;
     }
 
     .upload-btn:hover {
@@ -567,14 +578,15 @@
     }
 
     /* Uploaded maps list styling */
-    .uploaded-maps-list {
+.uploaded-maps-list {
       margin-bottom: 0.8rem;
-      max-height: 150px;
-      overflow-y: auto;
+      width: 100%;
       border: 1px solid #0af;
       border-radius: 8px;
       background: #232a36;
+      box-sizing: border-box;
       display: none; /* Hidden by default, shown when maps exist */
+      overflow: hidden;
     }
 
     .uploaded-maps-list:not(:empty) {
@@ -592,6 +604,9 @@
       color: #0af;
       font-size: 1rem;
       font-weight: bold;
+      box-sizing: border-box;
+      width: 100%;
+      overflow: hidden;
     }
 
     .uploaded-map-item:last-child {
@@ -635,6 +650,7 @@
       display: inline-block;
       position: relative;
       transition: transform 0.3s ease !important;
+      max-width: 100%;
     }
     
     /* Map rotation classes - applied to .map-content to rotate both image and canvas together */
@@ -656,4 +672,3 @@
       border: 3px dashed #f00 !important; /* DEBUG: show border when rotated */
       background: rgba(0,255,255,0.08) !important; /* DEBUG: show bg when rotated */
     }
-  </style>


### PR DESCRIPTION
## Summary
- Scale map containers and images so custom maps no longer cause horizontal scrolling
- Constrain sidebar controls and inputs to stay within the sidebar width
- Use a dark background across the page and sidebar
- Hide overflow on the custom map selector and list to remove scrollbars

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf479007c8333839246bd656a0814